### PR TITLE
first cut at getting cdp-based packages

### DIFF
--- a/scripts/cdp_manage
+++ b/scripts/cdp_manage
@@ -1,0 +1,1 @@
+cdp_manage.py

--- a/scripts/cdp_manage.py
+++ b/scripts/cdp_manage.py
@@ -1,0 +1,38 @@
+#!/usr/bin/env python
+
+import argparse
+import subprocess
+import shlex
+import sys
+
+P = argparse.ArgumentParser(
+    description='Runs PCMDI Metrics Computations',
+    formatter_class=argparse.ArgumentDefaultsHelpFormatter)
+
+P.add_argument(
+    "-l",
+    "--list",
+    action="store_true",
+    default=False,
+    help="List all cdp-based packages")
+P.add_argument(
+    "-c",
+    "--channel",
+    nargs="+",
+    default=[
+        "pcmdi",
+        "conda-forge",
+        "acme"],
+    help="Channel where to look")
+args = P.parse_args()
+
+if args.list:
+    cmd = "conda search -c %s --names-only --reverse-dependency cdp" % " -c ".join(
+        args.channel)
+    p = subprocess.Popen(shlex.split(cmd), stdout=subprocess.PIPE)
+    out = []
+    while p.poll() is None:
+        a = p.stdout.readline()
+        if len(a) > 0:
+            out.append(a)
+        sys.stdout.write(a)

--- a/setup.py
+++ b/setup.py
@@ -7,5 +7,6 @@ setup(
     author_email="shaheen2@llnl.gov",
     description="Framework for creating scientific diagnostics.",
     packages=find_packages(exclude=["*.test", "*.test.*", "test.*", "test"]),
-    include_package_data=True
+    include_package_data=True,
+    scripts = ["scripts/cdp_manage"]
 )


### PR DESCRIPTION
@zshaheen this is a first cut at what @williams13 wants, a list of all package that use cdp.

We/you can add option to bring all/any of them in.

We should probably have the command output as json (add `--json`) and then parse this so that we have the channels. I'll let you play with it, but here's the bare-bones:
```
cdp_manage -l
``
returns
```
Fetching package metadata ...............
acme_diags
acme_diags-nox
pcmdi_metrics
```

And the current help:
```
cdp_manage -h
usage: cdp_manage [-h] [-l] [-c CHANNEL [CHANNEL ...]]

CDP-based conda packages manager

optional arguments:
  -h, --help            show this help message and exit
  -l, --list            List all cdp-based packages (default: False)
  -c CHANNEL [CHANNEL ...], --channel CHANNEL [CHANNEL ...]
                        Channel where to look (default: ['pcmdi', 'conda-
                        forge', 'acme'])
```
