### PR TITLE
Cmdline fix

### DIFF
--- a/cdp/__init__.py
+++ b/cdp/__init__.py
@@ -8,3 +8,5 @@ from . import cdp_io
 from . import cdp_parser
 from . import cdp_run
 
+__version__ = 'v1.1.1'
+

--- a/cdp/cdp_parser.py
+++ b/cdp/cdp_parser.py
@@ -68,10 +68,10 @@ class CDPParser(argparse.ArgumentParser):
         """Parse the command line arguments while checking for the user's arguments"""
         if self.__args_namespace is None:
             self.__args_namespace = self.parse_args()            
-            if self.__args_namespace.parameters is None and self.__args_namespace.other_parameters is None:
-                print('You must have either the -p or -d arguments.')
-                self.print_help()
-                sys.exit()
+            # if self.__args_namespace.parameters is None and self.__args_namespace.other_parameters is None:
+            #     print('You must have either the -p or -d arguments.')
+            #     self.print_help()
+            #     sys.exit()
 
     def get_orig_parameters(self, default_vars=True, check_values=True):
         """Returns the parameters created by -p. If -p wasn't used, returns None."""
@@ -178,6 +178,22 @@ class CDPParser(argparse.ArgumentParser):
                 if var not in vars_to_ignore:
                     parameters.__dict__[var] = orig_parameters.__dict__[var]
 
+    def get_parameters_from_cmd_line(self, check_values=True):
+        """
+        Neither -p nor -d was used, so use the other command line args
+        to create a single parameters object.
+        """
+        parameter = self.__parameter_cls()
+
+        self._parse_arguments()
+
+        self._overwrite_parameters_with_cmdline_args(parameter)
+
+        if check_values:
+            parameter.check_values()
+
+        return parameter
+
     def get_parameters(self, orig_parameters=None, other_parameters=[], vars_to_ignore=[], *args, **kwargs):
         """Get the parameters based on the command line arguments and return a list of them."""
         if orig_parameters is None:
@@ -192,8 +208,8 @@ class CDPParser(argparse.ArgumentParser):
         elif orig_parameters is not None and other_parameters != []:  # used -p and -d
             self.combine_orig_and_other_params(orig_parameters, other_parameters, vars_to_ignore)
             return other_parameters
-        else:
-            raise RuntimeError("You ran your script without a '-p' or '-d' argument.")
+        else:  # just used command line arguments
+            return [self.get_parameters_from_cmd_line(*args, **kwargs)]
 
     def get_parameter(self, warning=False, *args, **kwargs):
         """Return the first Parameter in the list of Parameters."""

--- a/cdp/test/parameter_files/test_cmdline_args_with_default_values.py
+++ b/cdp/test/parameter_files/test_cmdline_args_with_default_values.py
@@ -1,0 +1,1 @@
+something_else = 10

--- a/cdp/test/parameter_files/test_cmdline_args_with_default_values2.py
+++ b/cdp/test/parameter_files/test_cmdline_args_with_default_values2.py
@@ -1,0 +1,1 @@
+default_val = 'default_val_from_py'

--- a/cdp/test/parameter_files/test_get_orig_parameters.py
+++ b/cdp/test/parameter_files/test_get_orig_parameters.py
@@ -1,0 +1,1 @@
+param1='py_param1'

--- a/cdp/test/parameter_files/test_get_orig_parameters_with_cmdline_args.py
+++ b/cdp/test/parameter_files/test_get_orig_parameters_with_cmdline_args.py
@@ -1,1 +1,0 @@
-something="something"

--- a/cdp/test/test_cdp_parser.py
+++ b/cdp/test/test_cdp_parser.py
@@ -10,6 +10,11 @@ import cdp.cdp_parser
 class TestCDPParser(unittest.TestCase):
 
     class MyCDPParameter(cdp.cdp_parameter.CDPParameter):
+        def __init__(self):
+            self.vars = ['default_vars']
+            self.param1 = 'param1'
+            self.param2 = 'param2'
+
         def check_values(self):
             pass
 
@@ -48,11 +53,36 @@ class TestCDPParser(unittest.TestCase):
     def test_load_custom_args(self):
         self.cdp_parser.add_args_and_values(['-v', 'v1', 'v2'])
 
-    def test_get_orig_parameters_with_cmdline_args(self):
-        self.cdp_parser.add_args_and_values(['-p', self.prefix + 'test_get_orig_parameters_with_cmdline_args.py', '-v', 'v1', 'v2'])
+    def test_get_orig_parameters(self):
+        self.cdp_parser.add_args_and_values(['-p', self.prefix + 'test_get_orig_parameters.py'])
+        p = self.cdp_parser.get_orig_parameters()
+        self.assertTrue(hasattr(p, 'param1'))
+        self.assertEqual(p.param1, 'py_param1')
+
+        self.cdp_parser.add_args_and_values(['-p', self.prefix + 'test_get_orig_parameters.py', '-v', 'v1', 'v2'])
         p = self.cdp_parser.get_orig_parameters()
         self.assertTrue(hasattr(p, 'vars'))
         self.assertEqual(p.vars, ['v1', 'v2'])
+        p = self.cdp_parser.get_orig_parameters(default_vars=False)
+        self.assertEqual(getattr(p, 'param2', None), None)
+
+        self.cdp_parser.add_argument(
+            '--param2',
+            type=str,
+            dest='param2',
+            default='param2_cmd_default',
+            required=False)
+
+        p = self.cdp_parser.get_orig_parameters(default_vars=False, cmd_default_vars=False)
+        self.assertEqual(p.param1, 'py_param1')
+        self.assertEqual(getattr(p, 'param2', None), None)
+
+        self.cdp_parser.add_args_and_values(['-p', self.prefix + 'test_get_orig_parameters.py'])
+        p = self.cdp_parser.get_orig_parameters(default_vars=False, cmd_default_vars=True)
+        self.assertEqual(p.param2, 'param2_cmd_default')
+        self.cdp_parser.add_args_and_values(['-p', self.prefix + 'test_get_orig_parameters.py', '--param2', 'new_param2'])
+        p = self.cdp_parser.get_orig_parameters(default_vars=False, cmd_default_vars=True)
+        self.assertEqual(p.param2, 'new_param2')
 
     def test_get_other_parameters(self):
         json_str = '''
@@ -63,8 +93,7 @@ class TestCDPParser(unittest.TestCase):
                         "param2": 2
                     },
                     {
-                        "param1": "one",
-                        "param2": "two"
+                        "param1": "one"
                     }
                 ]
             }
@@ -72,7 +101,7 @@ class TestCDPParser(unittest.TestCase):
         try:
             self.write_file('test_get_other_parameters.json', json_str)
             self.cdp_parser.add_args_and_values(['-d', 'test_get_other_parameters.json'])
-            p = self.cdp_parser.get_other_parameters()
+            p = self.cdp_parser.get_other_parameters(default_vars=True)
 
             self.assertEqual(len(p), 2)
             self.assertTrue(hasattr(p[0], 'param1'))
@@ -80,12 +109,83 @@ class TestCDPParser(unittest.TestCase):
             self.assertEqual(p[0].param1, 1)
             self.assertEqual(p[0].param2, 2)
             self.assertEqual(p[1].param1, 'one')
-            self.assertEqual(p[1].param2, 'two')
+            self.assertEqual(p[1].param2, 'param2')
+
+            self.cdp_parser.add_args_and_values(['-d', 'test_get_other_parameters.json'])
+            p = self.cdp_parser.get_other_parameters(default_vars=False)
+            self.assertEqual(getattr(p[1], 'param2', None), None)
+
+            self.cdp_parser.add_argument(
+                '--param2',
+                type=str,
+                dest='param2',
+                default='param2_cmd_default',
+                required=False)
+
+            self.cdp_parser.add_args_and_values(['-d', 'test_get_other_parameters.json'])
+            p = self.cdp_parser.get_other_parameters(default_vars=False, cmd_default_vars=False)
+            self.assertEqual(p[1].param1, 'one')
+            self.assertEqual(getattr(p[1], 'param2', None), None)
+
+            self.cdp_parser.add_args_and_values(['-d', 'test_get_other_parameters.json'])
+            p = self.cdp_parser.get_other_parameters(default_vars=False, cmd_default_vars=True)
+            self.assertEqual(p[1].param2, 'param2_cmd_default')
+            self.cdp_parser.add_args_and_values(['-d', 'test_get_other_parameters.json', '--param2', 'new_param2'])
+            p = self.cdp_parser.get_other_parameters(default_vars=False, cmd_default_vars=True)
+            self.assertEqual(p[1].param2, 'new_param2')
 
         finally:
             if os.path.exists('test_get_other_parameters.json'):
                 os.remove('test_get_other_parameters.json')
-        
+
+    def test_get_cmdline_parameters(self):
+        self.cdp_parser.add_argument(
+            '--default_val',
+            type=str,
+            dest='default_val',
+            default='default_val',
+            required=False)
+
+        self.cdp_parser.add_args_and_values(['-v', 'v1', 'v2', 'v3'])
+        params = self.cdp_parser.get_cmdline_parameters()
+        params2 = self.cdp_parser.get_parameter()
+        self.assertEqual(params.vars, ['v1', 'v2', 'v3'])
+        self.assertEqual(params2.vars, ['v1', 'v2', 'v3'])
+        self.assertEqual(params.default_val, 'default_val')
+
+        # default_vars=True, check_values=True, cmd_default_vars=True
+        # testing cmd_default_vars=False
+        params = self.cdp_parser.get_cmdline_parameters(cmd_default_vars=False)
+        self.assertEqual(getattr(params, 'default_val', None), None)
+
+        # testing default_vars=True and cmd_default_vars=False
+        self.cdp_parser.add_args_and_values(['--default_val', 'cmdline_val'])
+        params = self.cdp_parser.get_cmdline_parameters(cmd_default_vars=False)
+        self.assertEqual(params.vars, ['default_vars'])
+
+        # testing default_vars=False and cmd_default_vars=False
+        self.cdp_parser.add_args_and_values(['--default_val', 'cmdline_val'])
+        params = self.cdp_parser.get_cmdline_parameters(default_vars=False, cmd_default_vars=False)
+        self.assertEqual(getattr(params, 'vars', None), None)
+
+    def test__were_cmdline_args_used(self):
+        cfg_str = '[Diags1]\n' 
+        cfg_str += "num = 5\n"
+
+        try:
+            self.write_file('test__were_cmdline_args_used.cfg', cfg_str)
+            self.cdp_parser.add_args_and_values(['-d', 'test__were_cmdline_args_used.cfg'])
+            self.assertFalse(self.cdp_parser._were_cmdline_args_used())
+
+            self.cdp_parser.add_args_and_values(['-d', 'test__were_cmdline_args_used.cfg', '-v', 'v1'])
+            self.assertTrue(self.cdp_parser._were_cmdline_args_used())
+            self.cdp_parser.add_args_and_values(['-v', 'v1'])
+            self.assertTrue(self.cdp_parser._were_cmdline_args_used())
+
+        finally:
+            if os.path.exists('test__were_cmdline_args_used.cfg'):
+                os.remove('test__were_cmdline_args_used.cfg')
+
     def test_get_other_parameters_with_many_jsons(self):
         json_str = '''
             {
@@ -167,19 +267,26 @@ class TestCDPParser(unittest.TestCase):
     def test_get_parameters(self):
         cfg_str = '[Diags1]\n'
         cfg_str += "num = 5\n"
-        cfg_str += "path = my/output/dir\n"
         cfg_str += "vars = ['v2']\n"
 
         try:
             self.write_file('test_get_parameters.cfg', cfg_str)
 
-            self.cdp_parser.add_args_and_values(['-p', self.prefix + 'test_get_parameters.py', '-d', 'test_get_parameters.cfg', '-v', 'v3'])
+            self.cdp_parser.add_args_and_values(['-p', self.prefix + 'test_get_parameters.py'])
             p = self.cdp_parser.get_parameters()[0]
-
             self.assertEqual(p.num, 10)
             self.assertEqual(p.other_num, 11)
-            self.assertEqual(p.path, 'my/output/dir')
+            self.assertEqual(p.vars, ['v1'])
+
+            self.cdp_parser.add_args_and_values(['-d', 'test_get_parameters.cfg'])
+            p = self.cdp_parser.get_parameters()[0]
+            self.assertEqual(p.num, 5)
+            self.assertEqual(p.vars, ['v2'])
+
+            self.cdp_parser.add_args_and_values(['-v', 'v3'])
+            p = self.cdp_parser.get_parameters()[0]
             self.assertEqual(p.vars, ['v3'])
+
         finally:
             if os.path.exists('test_get_parameters.cfg'):
                 os.remove('test_get_parameters.cfg')
@@ -301,19 +408,6 @@ class TestCDPParser(unittest.TestCase):
             # if os.path.exists('test_cmdline_args_with_default_values2.py'):
             #    os.remove('test_cmdline_args_with_default_values2.py')
             pass
-
-    def test_with_cmdline_args_only(self):
-        self.cdp_parser.add_argument(
-                '--default_val',
-                type=str,
-                dest='default_val',
-                default='default_val',
-                required=False)
-
-        self.cdp_parser.add_args_and_values(['-v', 'v1', 'v2', 'v3'])
-        params = self.cdp_parser.get_parameter()
-        self.assertEqual(params.vars, ['v1', 'v2', 'v3'])
-        self.assertEqual(params.default_val, 'default_val')
-
+    
 if __name__ == '__main__':
     unittest.main()

--- a/cdp/test/test_cdp_parser.py
+++ b/cdp/test/test_cdp_parser.py
@@ -183,7 +183,7 @@ class TestCDPParser(unittest.TestCase):
         finally:
             if os.path.exists('test_get_parameters.cfg'):
                 os.remove('test_get_parameters.cfg')
-                
+
     def test_get_parameters_with_p_only(self):
         self.cdp_parser.add_args_and_values(['-p', self.prefix + 'test_get_parameters_with_p_only.py'])
         p = self.cdp_parser.get_parameters()[0]
@@ -301,6 +301,19 @@ class TestCDPParser(unittest.TestCase):
             # if os.path.exists('test_cmdline_args_with_default_values2.py'):
             #    os.remove('test_cmdline_args_with_default_values2.py')
             pass
+
+    def test_with_cmdline_args_only(self):
+        self.cdp_parser.add_argument(
+                '--default_val',
+                type=str,
+                dest='default_val',
+                default='default_val',
+                required=False)
+
+        self.cdp_parser.add_args_and_values(['-v', 'v1', 'v2', 'v3'])
+        params = self.cdp_parser.get_parameter()
+        self.assertEqual(params.vars, ['v1', 'v2', 'v3'])
+        self.assertEqual(params.default_val, 'default_val')
 
 if __name__ == '__main__':
     unittest.main()

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ from setuptools import find_packages, setup
 
 setup(
     name="cdp",
-    version="1.1.0",
+    version="1.1.1",
     author="Zeshawn Shaheen",
     author_email="shaheen2@llnl.gov",
     description="Framework for creating scientific diagnostics.",


### PR DESCRIPTION
* Parser works when the `default` option is used in `argparse.ArgumentParser. add_argument()`
* Creating parameters with just command line options work