### PR TITLE
Parser can run without any args.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -22,9 +22,9 @@ script:
   - conda update -q conda
   - conda config --set anaconda_upload no
 
-  - conda install python=$TRAVIS_PYTHON_VERSION output_viewer pyyaml dask distributed six -c conda-forge -c uvcdat -y
+  - conda install python=$TRAVIS_PYTHON_VERSION output_viewer pyyaml dask distributed six nose -c conda-forge -c uvcdat -y
 
-  - bash cdp/test/test.sh
+  - nosetests cdp/test/test_*.py
 
 after_success:
   - if [ "$TRAVIS_BRANCH" == "master" -a "$TRAVIS_PULL_REQUEST" == "false" ]; then

--- a/cdp/test/test_cdp_parser.py
+++ b/cdp/test/test_cdp_parser.py
@@ -498,6 +498,44 @@ class TestCDPParser(unittest.TestCase):
             # if os.path.exists('test_cmdline_args_with_default_values2.py'):
             #    os.remove('test_cmdline_args_with_default_values2.py')
             pass
+    
+    def test_without_any_params(self):
+            self.cdp_parser.add_argument(
+                '--param1',
+                type=str,
+                dest='param1',
+                default='param1_cmd_default',
+                required=False)
 
+            self.cdp_parser.add_argument(
+                '--new_param',
+                type=str,
+                dest='new_param',
+                default='new_param_cmd_default',
+                required=False)
+
+            # params should only have the defaults from the command line parser
+            # only vars and param1 are in the command line parser, make sure that param2 didn't show up
+            self.cdp_parser.add_args_and_values('')
+            params = self.cdp_parser.get_parameter()
+            self.assertTrue(hasattr(params, 'vars')) 
+            self.assertTrue(hasattr(params, 'param1'))
+            self.assertTrue(hasattr(params, 'new_param'))
+            self.assertTrue(hasattr(params, 'param2'))
+            self.assertEqual(params.vars, None)
+            self.assertEqual(params.param1, 'param1_cmd_default')
+            self.assertEqual(params.new_param, 'new_param_cmd_default')
+            self.assertEqual(params.param2, 'param2')
+
+            self.cdp_parser.add_args_and_values('')
+            params = self.cdp_parser.get_parameter(cmd_default_vars=False)
+            self.assertTrue(hasattr(params, 'vars')) 
+            self.assertTrue(hasattr(params, 'param1'))
+            self.assertTrue(hasattr(params, 'param2'))
+            self.assertFalse(hasattr(params, 'new_param'))
+            self.assertEqual(params.vars, ['default_vars'])
+            self.assertEqual(params.param1, 'param1')
+            self.assertEqual(params.param2, 'param2')
+    
 if __name__ == '__main__':
     unittest.main()

--- a/circle.yml
+++ b/circle.yml
@@ -12,16 +12,16 @@ dependencies:
     - ${HOME}/miniconda/bin/conda config --set always_yes yes --set changeps1 no
     - ${HOME}/miniconda/bin/conda update -q conda
     - ${HOME}/miniconda/bin/conda config --set anaconda_upload no
-    - PATH=${HOME}/miniconda/bin:${PATH} conda create -n python2 python=2.7 output_viewer pyyaml dask distributed six -c conda-forge -c uvcdat -y
-    - PATH=${HOME}/miniconda/bin:${PATH} conda create -n python3 python=3.6 output_viewer pyyaml dask distributed six -c conda-forge -c uvcdat -y
+    - PATH=${HOME}/miniconda/bin:${PATH} conda create -n python2 python=2.7 output_viewer pyyaml dask distributed six nose -c conda-forge -c uvcdat -y
+    - PATH=${HOME}/miniconda/bin:${PATH} conda create -n python3 python=3.6 output_viewer pyyaml dask distributed six nose -c conda-forge -c uvcdat -y
 
 
 test:
   override:
     - PATH=${HOME}/miniconda/bin:${PATH} source activate python2
-    - UVCDAT_ANONYMOUS_LOG=False bash ./cdp/test/test.sh
+    - UVCDAT_ANONYMOUS_LOG=False nosetests cdp/test/test_*.py
     - PATH=${HOME}/miniconda/bin:${PATH} source activate python3
-    - UVCDAT_ANONYMOUS_LOG=False bash ./cdp/test/test.sh
+    - UVCDAT_ANONYMOUS_LOG=False nosetests cdp/test/test_*.py
 
     - >
       if [ $? == 0 -a $CIRCLE_BRANCH == "master" ]; then


### PR DESCRIPTION
* You can now do stuff like: 
   ```
   $ my_driver.py
   ```
   and it works. Note that there aren't any arguments (`-*`, `--*`) or parameter files (`-p`, `-d`).