### PR TITLE
Having multiple titles as '[#]' works

### DIFF
--- a/cdp/test/test_cdp_parser.py
+++ b/cdp/test/test_cdp_parser.py
@@ -7,7 +7,6 @@ import cdp.cdp_parameter
 import cdp.cdp_parser
 import os
 
-'''
 class TestCDPParserOverload(unittest.TestCase):
     def setUp(self):
         pth = os.path.join(os.path.dirname(__file__),"json_files")
@@ -30,7 +29,6 @@ class TestCDPParserOverload(unittest.TestCase):
         self.my_parser.add_argument("--mns2","--modnames2",dest="modnames2",default="NEW")
         p = self.my_parser.get_parameter()
         self.assertTrue(p.modnames2 == "NEW")
-'''
 
 class TestCDPParser(unittest.TestCase):
 

--- a/cdp/test/test_cdp_parser.py
+++ b/cdp/test/test_cdp_parser.py
@@ -7,6 +7,7 @@ import cdp.cdp_parameter
 import cdp.cdp_parser
 import os
 
+'''
 class TestCDPParserOverload(unittest.TestCase):
     def setUp(self):
         pth = os.path.join(os.path.dirname(__file__),"json_files")
@@ -29,6 +30,7 @@ class TestCDPParserOverload(unittest.TestCase):
         self.my_parser.add_argument("--mns2","--modnames2",dest="modnames2",default="NEW")
         p = self.my_parser.get_parameter()
         self.assertTrue(p.modnames2 == "NEW")
+'''
 
 class TestCDPParser(unittest.TestCase):
 
@@ -567,7 +569,8 @@ class TestCDPParser(unittest.TestCase):
         cfg_str += "faces = [':)']\n"
         cfg_str += "dont_granulate = ['dont', 'granulate', 'this']\n"
         cfg_str += "info = 'This is some information.'\n"
-        cfg_str += "granulate = [nums, letters, faces]\n"
+        cfg_str += "empty=[]\n"
+        cfg_str += "granulate = [nums, letters, faces, empty]\n"
 
         try:
             self.write_file('test_granulate.cfg', cfg_str)
@@ -592,12 +595,42 @@ class TestCDPParser(unittest.TestCase):
                 self.assertEqual(getattr(p, 'faces'), [':)'])
                 self.assertEqual(getattr(p, 'dont_granulate'), ['dont', 'granulate', 'this'])
                 self.assertEqual(getattr(p, 'info'), 'This is some information.')
-                self.assertEqual(getattr(p, 'granulate'), ['nums', 'letters', 'faces'])
+                self.assertEqual(getattr(p, 'granulate'), ['nums', 'letters', 'faces', 'empty'])
 
         finally:
             if os.path.exists('test_granulate.cfg'):
                 os.remove('test_granulate.cfg')
 
+    def test_cfg_hash(self):
+        cfg_str = '[#]\n'
+        cfg_str += '[#]\n'
+        cfg_str += "num = 0\n"
+        cfg_str += '[#]\n'
+        cfg_str += "num = 0\n"
+        cfg_str += "num1 = 1\n"
+        cfg_str += '[Diags1]\n'
+        cfg_str += "num = 0\n"
+        cfg_str += "num = 0\n"
+        cfg_str += '[#]\n'
+        cfg_str += "num = 0\n"
+        cfg_str += "num1 = 1\n"
+        cfg_str += '[#]'
 
+        try:
+            self.write_file('test_cfg_hash.cfg', cfg_str)
+            self.cdp_parser.add_args_and_values(['-d', 'test_cfg_hash.cfg'])
+            params = self.cdp_parser.get_parameters()
+            self.assertEqual(len(params), 6)
+            self.assertEqual(getattr(params[1], 'num'), 0)
+            self.assertEqual(getattr(params[2], 'num'), 0)
+            self.assertEqual(getattr(params[2], 'num1'), 1)
+            self.assertEqual(getattr(params[3], 'num'), 0)
+            self.assertEqual(getattr(params[4], 'num'), 0)
+            self.assertEqual(getattr(params[4], 'num1'), 1)
+
+        finally:
+            if os.path.exists('test_cfg_hash.cfg'):
+                os.remove('test_cfg_hash.cfg')
+        
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
* In `cfg` files, we can have multiple parameters with the title `[#]`. Instead of concatenating it into one large parameter, it creates seperate ones by hashing the contents under `[#]` and changing `[#]` to the hash. A random digit is also added to make it even more random.